### PR TITLE
Improve PHPUnit fixtures

### DIFF
--- a/src/test/php/predicate/AndPredicateTest.php
+++ b/src/test/php/predicate/AndPredicateTest.php
@@ -27,7 +27,7 @@ class AndPredicateTest extends TestCase
     /**
      * set up test environment
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->andPredicate = new AndPredicate(
                 function($value) { return 'foo' === $value; },

--- a/src/test/php/predicate/IsExistingDirectoryTest.php
+++ b/src/test/php/predicate/IsExistingDirectoryTest.php
@@ -26,7 +26,7 @@ class IsExistingDirectoryTest extends TestCase
     /**
      * set up test environment
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $root  = vfsStream::setup();
         $basic = vfsStream::newDirectory('basic')->at($root);


### PR DESCRIPTION
# Changed log
- According to the [PHPUnit fixture reference](https://phpunit.readthedocs.io/en/9.0/fixtures.html), improving PHPUnit fixtures and let all fixture method (setUp) be `protected function setUp(): void`.