### PR TITLE
Added support for array-subset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.2.0 (not released yet)
+
+* Added support for `ArraySubset`
+
 ## 6.1.0 (2020-11-15)
 
 * Ensured compatibility with PHP 8 (@jaapio)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 bovigo/assert
+namespace bovigo\assert;
 ==============
 
 Provides assertions for unit tests.
@@ -391,7 +392,6 @@ array nor an instance of `\ArrayAccess` are rejected.
 assertThat($value, hasKey('roland'));
 ```
 
-
 ### `doesNotHaveKey($key)`
 
 Tests that an array or an instance of `\ArrayAccess` does not have a key with
@@ -401,6 +401,11 @@ are neither an array nor an instance of `\ArrayAccess` are rejected.
 ```php
 assertThat($value, doesNotHaveKey('roland'));
 ```
+
+### `containsSubset($other)`
+_Available since release 6.2.0._
+
+Tests that `$other` contains the value.
 
 
 ### `matches($pattern)`

--- a/src/main/php/predicate/ContainsSubset.php
+++ b/src/main/php/predicate/ContainsSubset.php
@@ -1,0 +1,90 @@
+<?php
+declare(strict_types=1);
+/**
+ * This file is part of bovigo\assert.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace bovigo\assert\predicate;
+
+use SebastianBergmann\Comparator\ComparisonFailure;
+use SebastianBergmann\Exporter\Exporter;
+
+/**
+ * Predicate to test that an array contains another array
+ *
+ * @since 6.2.0
+ */
+class ContainsSubset extends Predicate
+{
+    /**  @var array<mixed> */
+    private $other;
+    /** @var ComparisonFailure|null */
+    private $diff;
+
+    /**
+     * @param array<mixed> $other
+     */
+    public function __construct(array $other)
+    {
+        $this->other = $other;
+    }
+
+    public function test($value): bool
+    {
+        if (!is_iterable($value)) {
+            return false;
+        }
+
+        // type cast $this->other & $value as an array to allow support in
+        // standard array functions.
+        $other = $this->toArray($this->other);
+        $value = $this->toArray($value);
+
+        $patched = array_replace_recursive($other, $value);
+
+        if ($other == $patched) {
+            return true;
+        }
+
+        $this->diff = new ComparisonFailure(
+            $patched,
+            $other,
+            var_export($patched, true),
+            var_export($other, true)
+        );
+
+        return false;
+    }
+
+    public function __toString(): string
+    {
+        if ($this->diff) {
+            return $this->diff->getDiff();
+        }
+
+        return '';
+    }
+
+    public function describeValue(Exporter $exporter, $value): string
+    {
+        return 'an array has the subset '.$exporter->export($value);
+    }
+
+    /**
+     * @param iterable<mixed> $other
+     * @return array<mixed>
+     */
+    private function toArray(iterable $other): array
+    {
+        if (\is_array($other)) {
+            return $other;
+        }
+        if ($other instanceof \ArrayObject) {
+            return $other->getArrayCopy();
+        }
+
+        return iterator_to_array($other);
+    }
+}

--- a/src/main/php/predicate/predicates.php
+++ b/src/main/php/predicate/predicates.php
@@ -260,6 +260,18 @@ function isNotAnArray(): Predicate
 }
 
 /**
+ * returns predicate which tests for array subset
+ *
+ * @api
+ * @param array<mixed> $other
+ * @since 6.2.0
+ */
+function containsSubset(array $other): ContainsSubset
+{
+    return new ContainsSubset($other);
+}
+
+/**
  * returns predicate which tests something is a boolean value
  *
  * @api

--- a/src/test/php/predicate/ContainsSubsetTest.php
+++ b/src/test/php/predicate/ContainsSubsetTest.php
@@ -1,0 +1,70 @@
+<?php
+declare(strict_types=1);
+/**
+ * This file is part of bovigo\assert.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace bovigo\assert\predicate;
+use PHPUnit\Framework\TestCase;
+
+use function bovigo\assert\assertFalse;
+use function bovigo\assert\assertTrue;
+/**
+ * Tests for bovigo\assert\predicate\containsSubset.
+ *
+ * @group predicate
+ * @group issue_22
+ * @since 6.2.0
+ */
+class ContainsSubsetTest extends TestCase
+{
+    /**
+     * @return  array<array<mixed>>
+     */
+    public function tuplesEvaluatingToTrue(): array
+    {
+        return [
+            [range('a', 'e'), range('a', 'e')],
+            [range('a', 'e'), range('a', 'c')],
+            [range('a', 'e'), []],
+            [['a' => 'b', 'c' => 'd'], ['a' => 'b', 'c' => 'd']],
+            [['a' => 'b', 'c' => 'd'], ['a' => 'b']],
+            [['a' => 'b', 'c' => 'd'], []],
+        ];
+    }
+
+    /**
+     * @param array<mixed> $subset
+     * @param array<mixed> $other
+     * @test
+     * @dataProvider  tuplesEvaluatingToTrue
+     */
+    public function evaluatesToTrue($other, $subset): void
+    {
+        assertTrue(containsSubset($other)->test($subset));
+    }
+
+    /**
+     * @return  array<array<mixed>>
+     */
+    public function tuplesEvaluatingToFalse(): array
+    {
+        return [
+            [range('a', 'e'), range('o', 't')],
+            [['a' => 'b', 'c' => 'd'], ['o' => 'p', 'q' => 'r']],
+        ];
+    }
+
+    /**
+     * @param array<mixed> $subset
+     * @param array<mixed> $other
+     * @test
+     * @dataProvider  tuplesEvaluatingToFalse
+     */
+    public function evaluatesToFalse($other, $subset): void
+    {
+        assertFalse(containsSubset($other)->test($subset));
+    }
+}


### PR DESCRIPTION
## Demo:                                                                                                                                                                  

### OK:

```
rio ~/rio/tests/integration bin/asynit Api/ProjectTest.php
Asynit Test suite

.                                              1 / 1 (100%)

Time: 0.32 seconds, Memory: 5.79MB

OK, Tests: 1, Assertions: 27. 
```

### KO:

```
rio ~/rio/tests/integration bin/asynit Api/ProjectTest.php
Asynit Test suite

F                                              1 / 1 (100%)

# Failures:

1) Rio\Tests\Api\ProjectTest::test_greg_can_get_orpis_project failed

bovigo\assert\AssertionFailure: Failed asserting that an array has the subset Array &0 (
    'inTrial' => true
)
--- Expected
+++ Actual
@@ @@
   'schedule' => NULL,
   'legacyCloudflareScript' => false,
   'subscription' => false,
-  'inTrial' => true,
+  'inTrial' => false,
 )
 in Api/ProjectTest.php:51 at /home/rio/rio/tests/integration/vendor/jolicode/asynit/src/Assert/Assertion.php:73

#0 Asynit\Assert\Assertion->evaluate() at /home/rio/rio/tests/integration/vendor/jolicode/asynit/src/Assert/AssertCaseTrait.php:576
#1 Asynit\TestCase->assert() at /home/rio/rio/tests/integration/vendor/jolicode/asynit/src/Assert/AssertCaseTrait.php:563
#2 Asynit\TestCase->assertArraySubset() at /home/rio/rio/tests/integration/Api/ProjectTest.php:51
#3 Rio\Tests\Api\ProjectTest->test_greg_can_get_orpis_project() at n/a:n/a
#4 Generator->send() at /home/rio/rio/tests/integration/vendor/amphp/amp/lib/Coroutine.php:118
#5 Amp\Coroutine->Amp\{closure}() at /home/rio/rio/tests/integration/vendor/amphp/amp/lib/Internal/Placeholder.php:149
#6 Amp\Coroutine->resolve() at /home/rio/rio/tests/integration/vendor/amphp/amp/lib/Coroutine.php:123
#7 Amp\Coroutine->Amp\{closure}() at /home/rio/rio/tests/integration/vendor/amphp/amp/lib/Internal/ResolutionQueue.php:70
#8 Amp\Internal\ResolutionQueue->__invoke() at /home/rio/rio/tests/integration/vendor/amphp/amp/lib/Internal/Placeholder.php:149
#9 Amp\Coroutine->resolve() at /home/rio/rio/tests/integration/vendor/amphp/amp/lib/Coroutine.php:123


Time: 0.37 seconds, 6.03MB

Failed, Tests: 1, Assertions: 26.

```
